### PR TITLE
removed antipiracy

### DIFF
--- a/IPA.Injector/AntiPiracy.cs
+++ b/IPA.Injector/AntiPiracy.cs
@@ -16,13 +16,7 @@ namespace IPA.Injector
         {
             var dataPlugins = Path.Combine(GameVersionEarly.ResolveDataPath(path), "Plugins");
 
-            return 
-                File.Exists(Path.Combine(path, "IGG-GAMES.COM.url")) ||
-                File.Exists(Path.Combine(path, "SmartSteamEmu.ini")) ||
-                File.Exists(Path.Combine(path, "GAMESTORRENT.CO.url")) ||
-                File.Exists(Path.Combine(dataPlugins, "BSteam crack.dll")) ||
-                File.Exists(Path.Combine(dataPlugins, "HUHUVR_steam_api64.dll")) ||
-                Directory.GetFiles(dataPlugins, "*.ini", SearchOption.TopDirectoryOnly).Length > 0;
+            return false;
         }
     }
 }


### PR DESCRIPTION
### DO NOT PIRATE THE GAME
It's very bad for the game developers and especially for indie game studios, such as beat games.

I own a legit copy of the game and I'm only doing this to try out history versions of the game with mods, which I can only find from pirated sources.